### PR TITLE
Allow server IPs and ports to be changed at runtime

### DIFF
--- a/Holojam/Network/Client.cs
+++ b/Holojam/Network/Client.cs
@@ -25,11 +25,11 @@ namespace Holojam.Network {
     /// <summary>
     /// Address of the central Holojam relay node.
     /// </summary>
-    public string serverAddress = "0.0.0.0";
+    [SerializeField] string serverAddress = "0.0.0.0";
 
-    public int upstreamPort = 9592;
-    public string multicastAddress = "239.0.2.4";
-    public int downstreamPort = 9591;
+    [SerializeField] int upstreamPort = 9592;
+    [SerializeField] string multicastAddress = "239.0.2.4";
+    [SerializeField] int downstreamPort = 9591;
 
     /// <summary>
     /// Global namespace for outgoing updates and events.
@@ -101,16 +101,42 @@ namespace Holojam.Network {
       global.emitter.SendEvent(label, flake);
     }
 
+    /// <summary>
+    /// Use this to change the IP address of the Holojam relay node you're connecting to while running the program.
+    /// This takes care of reconnecting to the server with the updated address.
+    /// </summary>
+    /// <param name="address">The IP address of the server you want to connect to. Must be a valid IP address.</param>
+    public void ChangeServerAddress(string address) {
+      Stop();
+      serverAddress = address;
+      Start();
+    }
+
+    /// <summary>
+    /// Starts the threads for sending and receiving data, at the address and ports that this object has been
+    /// configured with.
+    /// </summary>
+    internal void Start() {
+      emitter = new Emitter(serverAddress, upstreamPort);
+      sink = new Sink(multicastAddress, downstreamPort);
+      // Start threads
+      sink.Start();
+      emitter.Start();
+    }
+
+    /// <summary>
+    /// Stops the threads for sending and receiving data.
+    /// </summary>
+    internal void Stop() {
+      if (sink != null) { sink.Stop(); }
+      if (emitter != null) { emitter.Stop(); }
+    }
+
     void Awake() {
       staged = new List<Controller>();
       untracked = new List<Controller>();
 
-      emitter = new Emitter(serverAddress, upstreamPort);
-      sink = new Sink(multicastAddress, downstreamPort);
-
-      // Start threads
-      sink.Start();
-      emitter.Start();
+      Start();
     }
 
     /// <summary>
@@ -183,8 +209,7 @@ namespace Holojam.Network {
     #endif
 
     void OnDestroy() {
-      sink.Stop();
-      emitter.Stop();
+      Stop();
     }
 
     // Editor

--- a/Holojam/Network/Client.cs
+++ b/Holojam/Network/Client.cs
@@ -32,6 +32,14 @@ namespace Holojam.Network {
     [SerializeField] int downstreamPort = 9591;
 
     /// <summary>
+    /// Address of the central Holojam relay node.
+    /// </summary>
+    public string ServerAddress { get { return serverAddress; } }
+    public int UpstreamPort { get { return upstreamPort; } }
+    public string MulticastAddress { get { return multicastAddress; } }
+    public int DownstreamPort { get { return downstreamPort; } }
+
+    /// <summary>
     /// Global namespace for outgoing updates and events.
     /// </summary>
     public string sendScope = "Unity";
@@ -102,13 +110,32 @@ namespace Holojam.Network {
     }
 
     /// <summary>
-    /// Use this to change the IP address of the Holojam relay node you're connecting to while running the program.
+    /// Setter for changing the IP address of the Holojam relay node you're connecting to while running the program.
     /// This takes care of reconnecting to the server with the updated address.
     /// </summary>
     /// <param name="address">The IP address of the server you want to connect to. Must be a valid IP address.</param>
     public void ChangeServerAddress(string address) {
       Stop();
       serverAddress = address;
+      Start();
+    }
+
+    /// <summary>
+    /// Setter for changing the IP address and ports for both upstream and downstream communication at once.
+    /// This takes care of reconnecting to the server with the updated addresses and ports.
+    /// </summary>
+    /// <param name="serverAddress"></param>
+    /// <param name="upstreamPort"></param>
+    /// <param name="multicastAddress"></param>
+    /// <param name="downstreamPort"></param>
+    public void ChangeServerSettings(string serverAddress, int upstreamPort,
+                                     string multicastAddress, int downstreamPort)
+    {
+      Stop();
+      this.serverAddress = serverAddress;
+      this.upstreamPort = upstreamPort;
+      this.multicastAddress = multicastAddress;
+      this.downstreamPort = downstreamPort;
       Start();
     }
 

--- a/Holojam/Network/Editor/ClientEditor.cs
+++ b/Holojam/Network/Editor/ClientEditor.cs
@@ -11,14 +11,14 @@ namespace Holojam.Network {
     SerializedProperty serverAddress, upstreamPort, multicastAddress, downstreamPort;
     SerializedProperty sendScope, rate;
 
-    void OnEnable(){
+    void OnEnable() {
       serverAddress = serializedObject.FindProperty("serverAddress");
       upstreamPort = serializedObject.FindProperty("upstreamPort");
       multicastAddress = serializedObject.FindProperty("multicastAddress");
       downstreamPort = serializedObject.FindProperty("downstreamPort");
       sendScope = serializedObject.FindProperty("sendScope");
       rate = serializedObject.FindProperty("rate");
-      }
+    }
 
     public override void OnInspectorGUI() {
       serializedObject.Update();

--- a/Holojam/Network/Editor/ClientEditor.cs
+++ b/Holojam/Network/Editor/ClientEditor.cs
@@ -40,10 +40,9 @@ namespace Holojam.Network {
       }
       EditorGUILayout.PropertyField(sendScope);
 
-      // "Connect to new server address" button should only be shown if we changed the IP of the server while
-      // in run mode
+      // "Apply changes" button should only be shown if we changed the IP of the server while in run mode
       if (newServerAddress != serverAddress.stringValue && Application.isPlaying) {
-        if (GUILayout.Button("Connect to new server address")) {
+        if (GUILayout.Button("Apply changes")) {
           client.ChangeServerAddress(newServerAddress);
         }
       }

--- a/Holojam/Network/Editor/ClientEditor.cs
+++ b/Holojam/Network/Editor/ClientEditor.cs
@@ -5,53 +5,54 @@ using UnityEngine;
 using UnityEditor;
 using Holojam.Network;
 
-namespace Holojam.Network{
-   [CustomEditor(typeof(Client))]
-   public class ClientEditor : Editor{
-      SerializedProperty serverAddress, upstreamPort, multicastAddress, downstreamPort;
-      SerializedProperty sendScope, rate;
-      void OnEnable(){
-         serverAddress = serializedObject.FindProperty("serverAddress");
-         upstreamPort = serializedObject.FindProperty("upstreamPort");
-         multicastAddress = serializedObject.FindProperty("multicastAddress");
-         downstreamPort = serializedObject.FindProperty("downstreamPort");
-         sendScope = serializedObject.FindProperty("sendScope");
-         rate = serializedObject.FindProperty("rate");
+namespace Holojam.Network {
+  [CustomEditor(typeof(Client))]
+  public class ClientEditor : Editor {
+    SerializedProperty serverAddress, upstreamPort, multicastAddress, downstreamPort;
+    SerializedProperty sendScope, rate;
+
+    void OnEnable(){
+      serverAddress = serializedObject.FindProperty("serverAddress");
+      upstreamPort = serializedObject.FindProperty("upstreamPort");
+      multicastAddress = serializedObject.FindProperty("multicastAddress");
+      downstreamPort = serializedObject.FindProperty("downstreamPort");
+      sendScope = serializedObject.FindProperty("sendScope");
+      rate = serializedObject.FindProperty("rate");
       }
 
-      public override void OnInspectorGUI(){
-         serializedObject.Update();
+    public override void OnInspectorGUI() {
+      serializedObject.Update();
 
-         EditorGUILayout.PropertyField(serverAddress);
-         EditorGUILayout.PropertyField(sendScope);
+      EditorGUILayout.PropertyField(serverAddress);
+      EditorGUILayout.PropertyField(sendScope);
 
-         EditorGUIUtility.labelWidth = 64;
-         GUIStyle bold = new GUIStyle(EditorStyles.boldLabel);
-         GUIStyle style = new GUIStyle(EditorStyles.boldLabel);
+      EditorGUIUtility.labelWidth = 64;
+      GUIStyle bold = new GUIStyle(EditorStyles.boldLabel);
+      GUIStyle style = new GUIStyle(EditorStyles.boldLabel);
 
-         EditorGUILayout.Space();
-         EditorGUILayout.LabelField("Packets per Second",bold);
+      EditorGUILayout.Space();
+      EditorGUILayout.LabelField("Packets per Second", bold);
 
-         Client client = (Client)serializedObject.targetObject;
-         if(Application.isPlaying)
-            style.normal.textColor = client.sentPPS>0?
-               new Color(0.5f,1,0.5f):new Color(1,0.5f,0.5f);
-         EditorGUILayout.LabelField("Sent:",client.sentPPS.ToString(),style);
+      Client client = (Client)serializedObject.targetObject;
+      if(Application.isPlaying)
+        style.normal.textColor = client.sentPPS > 0 ?
+               new Color(0.5f, 1, 0.5f) : new Color(1, 0.5f, 0.5f);
+      EditorGUILayout.LabelField("Sent:", client.sentPPS.ToString(), style);
 
-         if(Application.isPlaying)
-            style.normal.textColor = client.receivedPPS>0?
-               new Color(0.5f,1,0.5f):new Color(1,0.5f,0.5f);
-         EditorGUILayout.LabelField("Received",client.receivedPPS.ToString(),style);
+      if(Application.isPlaying)
+        style.normal.textColor = client.receivedPPS > 0 ?
+               new Color(0.5f, 1, 0.5f) : new Color(1, 0.5f, 0.5f);
+      EditorGUILayout.LabelField("Received", client.receivedPPS.ToString(), style);
 
-         EditorGUILayout.Space();
-         EditorGUILayout.LabelField("Flakes",bold);
-         EditorStyles.label.wordWrap = true;
-         foreach(string s in client.threadData)
-            EditorGUILayout.LabelField(s);
-         if(!Application.isPlaying)
-            EditorGUILayout.LabelField("   (Paused)");
+      EditorGUILayout.Space();
+      EditorGUILayout.LabelField("Flakes", bold);
+      EditorStyles.label.wordWrap = true;
+      foreach(string s in client.threadData)
+        EditorGUILayout.LabelField(s);
+      if(!Application.isPlaying)
+        EditorGUILayout.LabelField("   (Paused)");
 
-         /*
+      /*
          EditorGUILayout.Space();
          EditorGUILayout.LabelField("Controllers",bold);
          style = new GUIStyle();
@@ -63,17 +64,17 @@ namespace Holojam.Network{
          }
          */
 
-         EditorGUILayout.Space();
-         EditorGUIUtility.labelWidth = 0;
-         client.advanced = EditorGUILayout.Foldout(client.advanced,"Advanced");
-         if(client.advanced){
-            EditorGUILayout.PropertyField(upstreamPort);
-            EditorGUILayout.PropertyField(multicastAddress);
-            EditorGUILayout.PropertyField(downstreamPort);
-            EditorGUILayout.PropertyField(rate);
-         }
-
-         serializedObject.ApplyModifiedProperties();
+      EditorGUILayout.Space();
+      EditorGUIUtility.labelWidth = 0;
+      client.advanced = EditorGUILayout.Foldout(client.advanced, "Advanced");
+      if(client.advanced) {
+        EditorGUILayout.PropertyField(upstreamPort);
+        EditorGUILayout.PropertyField(multicastAddress);
+        EditorGUILayout.PropertyField(downstreamPort);
+        EditorGUILayout.PropertyField(rate);
       }
-   }
+
+      serializedObject.ApplyModifiedProperties();
+      }
+  }
 }

--- a/Holojam/Network/Editor/ClientEditor.cs
+++ b/Holojam/Network/Editor/ClientEditor.cs
@@ -1,5 +1,5 @@
-﻿//ClientEditor.cs
-//Created by Aaron C Gaudette on 11.11.16
+﻿// ClientEditor.cs
+// Created by Holojam Inc. on 11.11.16
 
 using UnityEngine;
 using UnityEditor;
@@ -8,23 +8,23 @@ using Holojam.Network;
 namespace Holojam.Network {
   [CustomEditor(typeof(Client))]
   public class ClientEditor : Editor {
-    SerializedProperty serverAddress, upstreamPort, multicastAddress, downstreamPort;
+    SerializedProperty relayAddress, upstreamPort, multicastAddress, downstreamPort;
     SerializedProperty sendScope, rate;
 
-    string newServerAddress = "?";
+    string newRelayAddress = "?";
     int newUpstreamPort = -1;
     string newMulticastAddress = "?";
     int newDownstreamPort = -1;
 
     void OnEnable() {
-      serverAddress = serializedObject.FindProperty("serverAddress");
+      relayAddress = serializedObject.FindProperty("relayAddress");
       upstreamPort = serializedObject.FindProperty("upstreamPort");
       multicastAddress = serializedObject.FindProperty("multicastAddress");
       downstreamPort = serializedObject.FindProperty("downstreamPort");
       sendScope = serializedObject.FindProperty("sendScope");
       rate = serializedObject.FindProperty("rate");
 
-      newServerAddress = serverAddress.stringValue;
+      newRelayAddress = relayAddress.stringValue;
       newUpstreamPort = upstreamPort.intValue;
       newMulticastAddress = multicastAddress.stringValue;
       newDownstreamPort = downstreamPort.intValue;
@@ -36,20 +36,21 @@ namespace Holojam.Network {
       Client client = (Client)serializedObject.targetObject;
 
       if (Application.isPlaying) {
-        // If we're in run mode, we need to go through the API to change the server address so that we restart the
-        // sending and receiving threads and so on.
-        newServerAddress = EditorGUILayout.TextField("Server Address", newServerAddress);
+        // If we're in run mode, we need to go through the API to change the server address so that
+        // we restart the sending and receiving threads and so on.
+        newRelayAddress = EditorGUILayout.TextField("Relay Address", newRelayAddress);
       }
       else {
         // Otherwise, we can just change the serialized property directly.
-        EditorGUILayout.PropertyField(serverAddress);
+        EditorGUILayout.PropertyField(relayAddress);
       }
       EditorGUILayout.PropertyField(sendScope);
 
-      // "Apply changes" button should only be shown if we changed the IP of the server while in run mode
-      if (newServerAddress != serverAddress.stringValue && Application.isPlaying) {
+      // "Apply changes" button should only be shown if we changed the IP of the server
+      // while in run mode
+      if (newRelayAddress != relayAddress.stringValue && Application.isPlaying) {
         if (GUILayout.Button("Apply changes")) {
-          client.ChangeServerAddress(newServerAddress);
+          client.ChangeRelayAddress(newRelayAddress);
         }
       }
 
@@ -94,8 +95,8 @@ namespace Holojam.Network {
       client.advanced = EditorGUILayout.Foldout(client.advanced, "Advanced");
       if(client.advanced) {
         if (Application.isPlaying) {
-          // If we're in run mode, we need to go through the API to change these properties so that we restart the
-          // sending and receiving threads and so on.
+          // If we're in run mode, we need to go through the API to change these properties so that we
+          // restart the sending and receiving threads and so on.
           newUpstreamPort = EditorGUILayout.IntField("Upstream Port", newUpstreamPort);
           newMulticastAddress = EditorGUILayout.TextField("Multicast Address", newMulticastAddress);
           newDownstreamPort = EditorGUILayout.IntField("Downstream Port", newDownstreamPort);
@@ -114,7 +115,9 @@ namespace Holojam.Network {
                                       || newDownstreamPort != downstreamPort.intValue))
         {
           if (GUILayout.Button("Apply changes")) {
-            client.ChangeServerSettings(client.ServerAddress, newUpstreamPort, newMulticastAddress, newDownstreamPort);
+            client.ChangeClientSettings(
+              client.RelayAddress, newUpstreamPort, newMulticastAddress, newDownstreamPort
+            );
           }
         }
       }


### PR DESCRIPTION
This privatizes the variables like `serverAddress` in the Client class and so on, adds a few API calls to make up for it, and makes the Client inspector a bit more fancy to support changing these variables at runtime, complete with restarting the sink/emitter threads when the changes are made.