### PR TITLE
Abstraction of LabelerInstance

### DIFF
--- a/Holojam/Components/Labeler.cs
+++ b/Holojam/Components/Labeler.cs
@@ -36,14 +36,18 @@ namespace Holojam.Components {
         return g.name + ':' + count;
       }
     }
-
+    
     private static LabelerInstance instance;
-
-    public static LabelerInstance Instance {
-      get {
-        return (instance == null) ?
-          instance = new LabelerInstance() : instance;
+    
+    // <summary>
+    // wrapper for internal instance method, GenerateLabel,
+    // returns a new label upon request
+    // </summary>
+    public static string GenerateLabel(GameObject g) {
+      if (instance == null) {
+        instance = new LabelerInstance();
       }
+      return instance.GenerateLabel(g);
     }
   }
 }

--- a/Holojam/Components/SharedData.cs
+++ b/Holojam/Components/SharedData.cs
@@ -33,7 +33,7 @@ namespace Holojam.Components {
 
     protected override void Awake() {
       base.Awake();
-      label = Labeler.Instance.GenerateLabel(this.gameObject);
+      label = Labeler.GenerateLabel(this.gameObject);
     }
   }
 }

--- a/Holojam/Components/VirtualObject.cs
+++ b/Holojam/Components/VirtualObject.cs
@@ -46,7 +46,7 @@ namespace Holojam.Components {
 
     protected override void Awake() {
       base.Awake();
-      label = Labeler.Instance.GenerateLabel(this.gameObject);
+      label = Labeler.GenerateLabel(this.gameObject);
     }
 
     protected override void UpdateTracking() {


### PR DESCRIPTION
Normally abstracting away the instance would require additional work (i.e. implement wrappers for all new instance methods), but in this case I am not so sure that the class will increase in complexity, and it might be unnecessary to require the programmer to know to access an "Instance" in `Labeler`.
What are your thoughts? It could be that referring to an "Instance" is completely fine and that the costs of implementing wrappers for every new method (this may never happen) outweights the advantages of hiding implementation. This is internal code after all.

On another note, this implementation of automatic labeling does not recycle labels, even after a component is removed (this is even the case after an undo in the editor). Does this matter much, and regardless, is there a simple way of recycling labels without adding unnecessary overhead? (memory use, destructors, tracking, etc.) Maybe this is fine as-is.